### PR TITLE
Add vector flush and compaction

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -74,6 +75,11 @@ import org.apache.cassandra.schema.IndexMetadata;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.concurrent.OpOrder;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.index.VectorSimilarityFunction;
 
 /**
  * Manage metadata for each column index.
@@ -646,5 +652,28 @@ public class IndexContext
     public boolean isSegmentCompactionEnabled()
     {
         return this.segmentCompactionEnabled;
+    }
+
+    public FieldInfo createFieldInfo(int vectorDimension)
+    {
+        String name = this.getIndexName();
+        int number = 0;
+        boolean storeTermVector = false;
+        boolean omitNorms = false;
+        boolean storePayloads = false;
+        IndexOptions indexOptions = IndexOptions.NONE;
+        DocValuesType docValues = DocValuesType.NONE;
+        long dvGen = -1;
+        Map<String, String> attributes = Map.of();
+        int pointDimensionCount = 0;
+        int pointIndexDimensionCount = 0;
+        int pointNumBytes = 0;
+        VectorEncoding vectorEncoding = VectorEncoding.FLOAT32;
+        VectorSimilarityFunction vectorSimilarityFunction = VectorSimilarityFunction.COSINE;
+        boolean softDeletesField = false;
+
+        return new FieldInfo(name, number, storeTermVector, omitNorms, storePayloads, indexOptions, docValues,
+                             dvGen, attributes, pointDimensionCount, pointIndexDimensionCount, pointNumBytes,
+                             vectorDimension, vectorEncoding, vectorSimilarityFunction, softDeletesField);
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/SSTableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/SSTableIndex.java
@@ -139,9 +139,9 @@ public class SSTableIndex
     public List<RangeIterator> search(Expression expression,
                                       AbstractBounds<PartitionPosition> keyRange,
                                       SSTableQueryContext context,
-                                      boolean defer) throws IOException
+                                      boolean defer, int limit) throws IOException
     {
-        return searchableIndex.search(expression, keyRange, context, defer);
+        return searchableIndex.search(expression, keyRange, context, defer, limit);
     }
 
     public void populateSegmentView(SimpleDataSet dataSet)

--- a/src/java/org/apache/cassandra/index/sai/disk/SearchableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/SearchableIndex.java
@@ -62,7 +62,7 @@ public interface SearchableIndex extends Closeable
     public List<RangeIterator> search(Expression expression,
                                       AbstractBounds<PartitionPosition> keyRange,
                                       SSTableQueryContext context,
-                                      boolean defer) throws IOException;
+                                      boolean defer, int limit) throws IOException;
 
     public void populateSystemView(SimpleDataSet dataSet, SSTableReader sstable);
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/format/IndexComponent.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/IndexComponent.java
@@ -37,6 +37,11 @@ public enum IndexComponent
      */
     KD_TREE("KDTree"),
     KD_TREE_POSTING_LISTS("KDTreePostingLists"),
+
+    /**
+     * Lucene creates 3 vector files with ".vex", ".vec" and ".vem" extensions
+     */
+    VECTOR("Vector"),
     /**
      * Term dictionary written by {@code TrieTermsDictionaryWriter} stores mappings of term and
      * file pointer to posting block on posting file.

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcher.java
@@ -82,7 +82,7 @@ public class InvertedIndexSearcher extends IndexSearcher
 
     @Override
     @SuppressWarnings("resource")
-    public RangeIterator search(Expression exp, SSTableQueryContext context, boolean defer) throws IOException
+    public RangeIterator search(Expression exp, SSTableQueryContext context, boolean defer, int limit) throws IOException
     {
         if (logger.isTraceEnabled())
             logger.trace(indexContext.logMessage("Searching on expression '{}'..."), exp);

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/KDTreeIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/KDTreeIndexSearcher.java
@@ -77,7 +77,7 @@ public class KDTreeIndexSearcher extends IndexSearcher
 
     @Override
     @SuppressWarnings("resource")
-    public RangeIterator search(Expression exp, SSTableQueryContext context, boolean defer) throws IOException
+    public RangeIterator search(Expression exp, SSTableQueryContext context, boolean defer, int limit) throws IOException
     {
         if (logger.isTraceEnabled())
             logger.trace(indexContext.logMessage("Searching on expression '{}'..."), exp);

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/MemtableIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/MemtableIndexWriter.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.concurrent.TimeUnit;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,6 +68,7 @@ public class MemtableIndexWriter implements PerIndexWriter
     {
         assert rowMapping != null && rowMapping != RowMapping.DUMMY : "Row mapping must exist during FLUSH.";
 
+        Preconditions.checkState(!(indexContext.getValidator() instanceof DenseFloat32Type));
         this.indexDescriptor = indexDescriptor;
         this.indexContext = indexContext;
         this.memtable = memtable;
@@ -148,12 +150,7 @@ public class MemtableIndexWriter implements PerIndexWriter
         long numRows;
         SegmentMetadata.ComponentMetadataMap indexMetas;
 
-        if (termComparator instanceof DenseFloat32Type) {
-            numRows = 0;
-            indexMetas = null;
-            // TODO
-        }
-        else if (TypeUtil.isLiteral(termComparator))
+        if (TypeUtil.isLiteral(termComparator))
         {
             try (InvertedIndexWriter writer = new InvertedIndexWriter(indexDescriptor, indexContext, false))
             {

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/PerIndexFiles.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/PerIndexFiles.java
@@ -22,6 +22,7 @@ import java.io.Closeable;
 import java.util.EnumMap;
 import java.util.Map;
 
+import org.apache.cassandra.db.marshal.DenseFloat32Type;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.disk.format.IndexComponent;
 import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
@@ -39,7 +40,11 @@ public class PerIndexFiles implements Closeable
     {
         this.indexDescriptor = indexDescriptor;
         this.indexContext = indexContext;
-        if (TypeUtil.isLiteral(indexContext.getValidator()))
+        if (indexContext.getValidator() instanceof DenseFloat32Type)
+        {
+            // TODO  lucene doesn't follow SAI file patterns
+        }
+        else if (TypeUtil.isLiteral(indexContext.getValidator()))
         {
             files.put(IndexComponent.POSTING_LISTS, indexDescriptor.createPerIndexFileHandle(IndexComponent.POSTING_LISTS, indexContext, temporary));
             files.put(IndexComponent.TERMS_DATA, indexDescriptor.createPerIndexFileHandle(IndexComponent.TERMS_DATA, indexContext, temporary));

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SSTableIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SSTableIndexWriter.java
@@ -26,11 +26,13 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
 import javax.annotation.concurrent.NotThreadSafe;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.db.marshal.DenseFloat32Type;
 import org.apache.cassandra.db.rows.Row;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.analyzer.AbstractAnalyzer;
@@ -369,6 +371,9 @@ public class SSTableIndexWriter implements PerIndexWriter
 
     private SegmentBuilder newSegmentBuilder()
     {
+        // vector uses VectorIndexSearcher
+        Preconditions.checkState(!(indexContext.getValidator() instanceof DenseFloat32Type));
+
         SegmentBuilder builder = TypeUtil.isLiteral(indexContext.getValidator())
                                  ? new SegmentBuilder.RAMStringSegmentBuilder(indexContext.getValidator(), limiter)
                                  : new SegmentBuilder.KDTreeSegmentBuilder(indexContext.getValidator(), limiter, indexContext.getIndexWriterConfig());

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/Segment.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/Segment.java
@@ -127,13 +127,14 @@ public class Segment implements Closeable
      * Search on-disk index synchronously
      *
      * @param expression to filter on disk index
-     * @param context to track per sstable cache and per query metrics
-     * @param defer create the iterator in a deferred state
+     * @param context    to track per sstable cache and per query metrics
+     * @param defer      create the iterator in a deferred state
+     * @param limit
      * @return range iterator that matches given expression
      */
-    public RangeIterator search(Expression expression, SSTableQueryContext context, boolean defer) throws IOException
+    public RangeIterator search(Expression expression, SSTableQueryContext context, boolean defer, int limit) throws IOException
     {
-        return index.search(expression, context, defer);
+        return index.search(expression, context, defer, limit);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/V1SearchableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/V1SearchableIndex.java
@@ -158,7 +158,8 @@ public class V1SearchableIndex implements SearchableIndex
     public List<RangeIterator> search(Expression expression,
                                       AbstractBounds<PartitionPosition> keyRange,
                                       SSTableQueryContext context,
-                                      boolean defer) throws IOException
+                                      boolean defer,
+                                      int limit) throws IOException
     {
         List<RangeIterator> iterators = new ArrayList<>();
 
@@ -166,7 +167,7 @@ public class V1SearchableIndex implements SearchableIndex
         {
             if (segment.intersects(keyRange))
             {
-                iterators.add(segment.search(expression, context, defer));
+                iterators.add(segment.search(expression, context, defer, limit));
             }
         }
 

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/VectorIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/VectorIndexSearcher.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.disk.v1;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Map;
+
+import com.google.common.base.MoreObjects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.db.marshal.DenseFloat32Type;
+import org.apache.cassandra.index.sai.IndexContext;
+import org.apache.cassandra.index.sai.SSTableQueryContext;
+import org.apache.cassandra.index.sai.disk.IndexSearcherContext;
+import org.apache.cassandra.index.sai.disk.PostingList;
+import org.apache.cassandra.index.sai.disk.PostingListRangeIterator;
+import org.apache.cassandra.index.sai.disk.PrimaryKeyMap;
+import org.apache.cassandra.index.sai.disk.format.IndexComponent;
+import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
+import org.apache.cassandra.index.sai.plan.Expression;
+import org.apache.cassandra.index.sai.utils.RangeIterator;
+import org.apache.cassandra.io.util.File;
+import org.apache.cassandra.utils.Hex;
+import org.apache.lucene.codecs.KnnVectorsReader;
+import org.apache.lucene.codecs.lucene95.Lucene95Codec;
+import org.apache.lucene.codecs.lucene95.Lucene95HnswVectorsFormat;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.Version;
+
+/**
+ * Executes ann search against the HNSW graph for an individual index segment.
+ */
+public class VectorIndexSearcher extends IndexSearcher
+{
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    private final KnnVectorsReader reader;
+    VectorIndexSearcher(PrimaryKeyMap.Factory primaryKeyMapFactory,
+                        PerIndexFiles perIndexFiles, // TODO not used for now because lucene has different file extensions
+                        SegmentMetadata segmentMetadata,
+                        IndexDescriptor indexDescriptor,
+                        IndexContext indexContext) throws IOException
+    {
+        super(primaryKeyMapFactory, perIndexFiles, segmentMetadata, indexDescriptor, indexContext);
+
+        File vectorPath = indexDescriptor.fileFor(IndexComponent.VECTOR, indexContext);
+        Directory directory = FSDirectory.open(vectorPath.toPath().getParent());
+        String segmentName = vectorPath.name();
+
+        Map<String, String> configs = segmentMetadata.componentMetadatas.get(IndexComponent.VECTOR).attributes;
+        String segmentIdHex = configs.get("SEGMENT_ID");
+        byte[] segmentId = Hex.hexToBytes(segmentIdHex);
+
+        int maxDocId = Math.toIntExact(segmentMetadata.maxSSTableRowId); // TODO we don't support more than 2.1B docs per segment. Do not enable segment merging
+        SegmentInfo segmentInfo = new SegmentInfo(directory, Version.LATEST, Version.LATEST, segmentName, maxDocId, false, Lucene95Codec.getDefault(), Collections.emptyMap(), segmentId, Collections.emptyMap(), null);
+
+        int vectorDimension = Integer.parseInt(configs.get("DIMENSION"));
+        FieldInfo fieldInfo = indexContext.createFieldInfo(vectorDimension);
+        FieldInfos fieldInfos = new FieldInfos(Collections.singletonList(fieldInfo).toArray(new FieldInfo[0]));
+        SegmentReadState state = new SegmentReadState(directory, segmentInfo, fieldInfos, IOContext.DEFAULT);
+        reader = new Lucene95HnswVectorsFormat().fieldsReader(state);
+    }
+
+    @Override
+    public long indexFileCacheSize()
+    {
+        return reader.ramBytesUsed();
+    }
+
+    @Override
+    @SuppressWarnings("resource")
+    public RangeIterator search(Expression exp, SSTableQueryContext context, boolean defer, int limit) throws IOException
+    {
+        if (logger.isTraceEnabled())
+            logger.trace(indexContext.logMessage("Searching on expression '{}'..."), exp);
+
+        if (exp.getOp() != Expression.Op.ANN)
+            throw new IllegalArgumentException(indexContext.logMessage("Unsupported expression during ANN index query: " + exp));
+
+        String field = indexContext.getIndexName();
+
+        ByteBuffer buffer = exp.lower.value.raw;
+        float[] queryVector = DenseFloat32Type.Serializer.instance.deserialize(buffer.duplicate());
+
+        Bits bits = null; // TODO filter partitions inside ANN search
+        TopDocs docs = reader.search(field, queryVector, limit, bits, Integer.MAX_VALUE);
+
+        if (docs.scoreDocs.length == 0)
+            return RangeIterator.empty();
+
+        IndexSearcherContext searcherContext = new IndexSearcherContext(metadata.minKey,
+                                                                        metadata.maxKey,
+                                                                        metadata.segmentRowIdOffset,
+                                                                        context,
+                                                                        new PostingList.PeekablePostingList(new TopDocsPostingList(docs.scoreDocs)));
+        return new PostingListRangeIterator(indexContext, primaryKeyMapFactory.newPerSSTablePrimaryKeyMap(context), searcherContext);
+    }
+
+    @Override
+    public String toString()
+    {
+        return MoreObjects.toStringHelper(this)
+                          .add("indexContext", indexContext)
+                          .toString();
+    }
+
+    @Override
+    public void close()
+    {
+    }
+
+    public static class TopDocsPostingList implements PostingList
+    {
+        private final ScoreDoc[] scoreDocs;
+        private int index = 0;
+
+        public TopDocsPostingList(ScoreDoc[] scoreDocs)
+        {
+            // sort by token/clustering order
+            Arrays.sort(scoreDocs, Comparator.comparingInt(l -> l.doc));
+            this.scoreDocs = scoreDocs;
+        }
+
+        @Override
+        public long nextPosting() throws IOException
+        {
+            if (index >= scoreDocs.length)
+                return PostingList.END_OF_STREAM;
+
+            ScoreDoc doc = scoreDocs[index++];
+            return doc.doc;
+        }
+
+        @Override
+        public long size()
+        {
+            return scoreDocs.length;
+        }
+
+        @Override
+        public long advance(long targetRowID) throws IOException
+        {
+            if (index >= scoreDocs.length)
+                return PostingList.END_OF_STREAM;
+
+            ScoreDoc doc = scoreDocs[index];
+            while (doc.doc < targetRowID)
+            {
+                index++;
+                if (index >= scoreDocs.length)
+                    return PostingList.END_OF_STREAM;
+
+                doc = scoreDocs[++index];
+            }
+
+            return doc.doc;
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/VectorIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/VectorIndexWriter.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.disk.v1;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Stopwatch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.db.marshal.DenseFloat32Type;
+import org.apache.cassandra.db.rows.Row;
+import org.apache.cassandra.index.sai.IndexContext;
+import org.apache.cassandra.index.sai.disk.PerIndexWriter;
+import org.apache.cassandra.index.sai.disk.format.IndexComponent;
+import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
+import org.apache.cassandra.index.sai.utils.PrimaryKey;
+import org.apache.cassandra.io.util.File;
+import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.FBUtilities;
+import org.apache.lucene.codecs.KnnFieldVectorsWriter;
+import org.apache.lucene.codecs.lucene95.Lucene95Codec;
+import org.apache.lucene.codecs.lucene95.Lucene95HnswVectorsFormat;
+import org.apache.lucene.codecs.lucene95.Lucene95HnswVectorsWriter;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.util.InfoStream;
+import org.apache.lucene.util.StringHelper;
+import org.apache.lucene.util.Version;
+
+/**
+ * Column index writer that HNSW graph writer
+ */
+public class VectorIndexWriter implements PerIndexWriter
+{
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    private final IndexDescriptor indexDescriptor;
+    private final IndexContext indexContext;
+    private final int nowInSec = FBUtilities.nowInSeconds();
+
+    private Lucene95HnswVectorsWriter writer;
+    private KnnFieldVectorsWriter fieldWriter;
+
+    private int dimension;
+    private byte[] segmentId;
+
+    private int maxDocId = -1;
+    private int vectors = 0;
+
+    private PrimaryKey minKey;
+    private PrimaryKey maxKey;
+
+    public VectorIndexWriter(IndexDescriptor indexDescriptor, IndexContext indexContext)
+    {
+        Preconditions.checkState(indexContext.getValidator() instanceof DenseFloat32Type);
+
+        this.indexDescriptor = indexDescriptor;
+        this.indexContext = indexContext;
+    }
+
+    @Override
+    public IndexContext indexContext()
+    {
+        return indexContext;
+    }
+
+    @Override
+    public void addRow(PrimaryKey key, Row row, long sstableRowId)
+    {
+        // Memtable indexes are flushed directly to disk with the aid of a mapping between primary
+        // keys and row IDs in the flushing SSTable. This writer, therefore, does nothing in
+        // response to the flushing of individual rows.
+
+
+        ByteBuffer value = indexContext.getValueOf(key.partitionKey(), row, nowInSec);
+        if (value != null)
+        {
+            float[] vector = DenseFloat32Type.Serializer.instance.deserialize(value.duplicate());
+            try
+            {
+                maybeCreateWriter(vector.length);
+
+                // we should not have more than 2.1B rows in memtable
+                int docId = Math.toIntExact(sstableRowId);
+                fieldWriter.addValue(docId, vector);
+
+                if (minKey == null)
+                    minKey = key;
+
+                maxKey = key;
+                vectors++;
+                maxDocId = Math.max(maxDocId, docId);
+            }
+            catch (IOException e)
+            {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private void maybeCreateWriter(int dimension)
+    {
+        try
+        {
+            if (fieldWriter != null)
+                return;
+
+            File vectorPath = indexDescriptor.fileFor(IndexComponent.VECTOR, indexContext);
+
+            Directory directory = FSDirectory.open(vectorPath.toPath().getParent());
+            String segmentName = vectorPath.name();
+
+            segmentId = StringHelper.randomId();
+            SegmentInfo segmentInfo = new SegmentInfo(directory, Version.LATEST, Version.LATEST, segmentName, -1, false, Lucene95Codec.getDefault(), Collections.emptyMap(), segmentId, Collections.emptyMap(), null);
+            SegmentWriteState state = new SegmentWriteState(InfoStream.getDefault(), directory, segmentInfo, null, null, IOContext.DEFAULT);
+            writer = (Lucene95HnswVectorsWriter) new Lucene95HnswVectorsFormat().fieldsWriter(state);
+
+            this.dimension = dimension;
+            FieldInfo fieldInfo = indexContext.createFieldInfo(dimension);
+            fieldWriter = writer.addField(fieldInfo);
+        }
+        catch (IOException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void abort(Throwable cause)
+    {
+        logger.warn(indexContext.logMessage("Aborting index memtable flush for {}..."), indexDescriptor.descriptor, cause);
+        indexDescriptor.deleteColumnIndex(indexContext);
+    }
+
+    @Override
+    public void complete(Stopwatch stopwatch) throws IOException
+    {
+        long start = stopwatch.elapsed(TimeUnit.MILLISECONDS);
+
+        try
+        {
+            if (vectors == 0)
+            {
+                logger.debug(indexContext.logMessage("No indexed rows to flush from SSTable {}."), indexDescriptor.descriptor);
+                // Write a completion marker even though we haven't written anything to the index
+                // so we won't try to build the index again for the SSTable
+                indexDescriptor.createComponentOnDisk(IndexComponent.COLUMN_COMPLETION_MARKER, indexContext);
+                return;
+            }
+
+            flushVectorIndex(stopwatch, start);
+
+            indexDescriptor.createComponentOnDisk(IndexComponent.COLUMN_COMPLETION_MARKER, indexContext);
+        }
+        catch (Throwable t)
+        {
+            logger.error(indexContext.logMessage("Error while flushing index {}"), t.getMessage(), t);
+            indexContext.getIndexMetrics().memtableIndexFlushErrors.inc();
+
+            throw t;
+        }
+    }
+
+    private void flushVectorIndex(Stopwatch stopwatch, long start) throws IOException
+    {
+        writer.flush(maxDocId, null); // no need to reorder with DocMap
+        writer.finish();
+        writer.close();
+
+        long elapsed = stopwatch.elapsed(TimeUnit.MILLISECONDS);
+
+        logger.debug(indexContext.logMessage("Completed flushing {} memtable index vectors to SSTable {}. Duration: {} ms. Total elapsed: {} ms"),
+                     vectors,
+                     indexDescriptor.descriptor,
+                     elapsed - start,
+                     elapsed);
+
+        indexContext.getIndexMetrics().memtableFlushCellsPerSecond.update((long) (vectors * 1000.0 / Math.max(1, elapsed - start)));
+
+        SegmentMetadata.ComponentMetadataMap metadataMap = new SegmentMetadata.ComponentMetadataMap();
+
+        // we don't care about root/offset/length for vector. segmentId is used in searcher
+        Map<String, String> vectorConfigs = Map.of("SEGMENT_ID", ByteBufferUtil.bytesToHex(ByteBuffer.wrap(segmentId)),
+                                                   "DIMENSION", String.valueOf(dimension));
+        metadataMap.put(IndexComponent.VECTOR, 0, 0, 0, vectorConfigs);
+
+        SegmentMetadata metadata = new SegmentMetadata(0,
+                                                       vectors,
+                                                       0,
+                                                       maxDocId,
+                                                       indexDescriptor.primaryKeyFactory.createPartitionKeyOnly(minKey.partitionKey()),
+                                                       indexDescriptor.primaryKeyFactory.createPartitionKeyOnly(maxKey.partitionKey()),
+                                                       ByteBufferUtil.bytes(0), // TODO by pass min max terms for vectors
+                                                       ByteBufferUtil.bytes(0), // TODO by pass min max terms for vectors
+                                                       metadataMap);
+
+        try (MetadataWriter writer = new MetadataWriter(indexDescriptor.openPerIndexOutput(IndexComponent.META, indexContext)))
+        {
+            SegmentMetadata.write(writer, Collections.singletonList(metadata));
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -48,6 +48,7 @@ import org.apache.cassandra.db.filter.ClusteringIndexFilter;
 import org.apache.cassandra.db.filter.ClusteringIndexNamesFilter;
 import org.apache.cassandra.db.filter.DataLimits;
 import org.apache.cassandra.db.filter.RowFilter;
+import org.apache.cassandra.db.marshal.DenseFloat32Type;
 import org.apache.cassandra.db.rows.UnfilteredRowIterator;
 import org.apache.cassandra.dht.AbstractBounds;
 import org.apache.cassandra.dht.Range;
@@ -384,7 +385,12 @@ public class QueryController
             View view = e.context.getView();
 
             NavigableSet<SSTableIndex> indexes = new TreeSet<>(SSTableIndex.COMPARATOR);
-            indexes.addAll(applyScope(view.match(e)));
+
+            // always search all for ANN
+            if (e.context.getValidator() instanceof DenseFloat32Type)
+                indexes.addAll(view.getIndexes());
+            else
+                indexes.addAll(applyScope(view.match(e)));
 
             if (expression == null || primaryIndexes.size() > indexes.size())
             {

--- a/src/java/org/apache/cassandra/index/sai/utils/TermIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/TermIterator.java
@@ -69,7 +69,7 @@ public class TermIterator extends RangeIterator
                 assert !index.isReleased();
 
                 SSTableQueryContext context = queryContext.getSSTableQueryContext(index.getSSTable());
-                List<RangeIterator> keyIterators = index.search(e, keyRange, context, defer);
+                List<RangeIterator> keyIterators = index.search(e, keyRange, context, defer, limit);
 
                 if (keyIterators == null || keyIterators.isEmpty())
                     continue;

--- a/test/unit/org/apache/cassandra/index/sai/cql/AnnTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/AnnTest.java
@@ -23,6 +23,8 @@ import org.junit.Test;
 import org.apache.cassandra.cql3.UntypedResultSet;
 import org.apache.cassandra.index.sai.SAITester;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class AnnTest extends SAITester
 {
     @Test
@@ -38,7 +40,24 @@ public class AnnTest extends SAITester
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'D', [4.0, 5.0, 6.0])");
 
         UntypedResultSet result = execute("SELECT * FROM %s WHERE val ann [2.5, 3.5, 4.5] LIMIT 5");
+        assertThat(result).hasSizeGreaterThan(0);
+        System.out.println(makeRowStrings(result));
 
+        flush();
+        result = execute("SELECT * FROM %s WHERE val ann [2.5, 3.5, 4.5] LIMIT 5");
+        assertThat(result).hasSizeGreaterThan(0);
+        System.out.println(makeRowStrings(result));
+
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'E', [5.0, 2.0, 3.0])");
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'F', [6.0, 3.0, 4.0])");
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'G', [7.0, 4.0, 5.0])");
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'H', [8.0, 5.0, 6.0])");
+
+        flush();
+        compact();
+
+        result = execute("SELECT * FROM %s WHERE val ann [2.5, 3.5, 4.5] LIMIT 5");
+        assertThat(result).hasSizeGreaterThan(0);
         System.out.println(makeRowStrings(result));
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcherTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcherTest.java
@@ -49,6 +49,8 @@ import static org.hamcrest.Matchers.is;
 
 public class InvertedIndexSearcherTest extends SaiRandomizedTest
 {
+    public static final int LIMIT = Integer.MAX_VALUE;
+
     @BeforeClass
     public static void setupCQLTester()
     {
@@ -72,7 +74,7 @@ public class InvertedIndexSearcherTest extends SaiRandomizedTest
             for (int t = 0; t < numTerms; ++t)
             {
                 try (RangeIterator results = searcher.search(new Expression(SAITester.createIndexContext("meh", UTF8Type.instance))
-                        .add(Operator.EQ, wrap(termsEnum.get(t).left)), SSTableQueryContext.forTest(), false))
+                        .add(Operator.EQ, wrap(termsEnum.get(t).left)), SSTableQueryContext.forTest(), false, LIMIT))
                 {
                     assertEquals(results.getMinimum(), results.getCurrent());
                     assertTrue(results.hasNext());
@@ -88,7 +90,7 @@ public class InvertedIndexSearcherTest extends SaiRandomizedTest
                 }
 
                 try (RangeIterator results = searcher.search(new Expression(SAITester.createIndexContext("meh", UTF8Type.instance))
-                        .add(Operator.EQ, wrap(termsEnum.get(t).left)), SSTableQueryContext.forTest(), false))
+                        .add(Operator.EQ, wrap(termsEnum.get(t).left)), SSTableQueryContext.forTest(), false, LIMIT))
                 {
                     assertEquals(results.getMinimum(), results.getCurrent());
                     assertTrue(results.hasNext());
@@ -111,12 +113,12 @@ public class InvertedIndexSearcherTest extends SaiRandomizedTest
             // try searching for terms that weren't indexed
             final String tooLongTerm = randomSimpleString(10, 12);
             RangeIterator results = searcher.search(new Expression(SAITester.createIndexContext("meh", UTF8Type.instance))
-                                                                .add(Operator.EQ, UTF8Type.instance.decompose(tooLongTerm)), SSTableQueryContext.forTest(), false);
+                                                                .add(Operator.EQ, UTF8Type.instance.decompose(tooLongTerm)), SSTableQueryContext.forTest(), false, LIMIT);
             assertFalse(results.hasNext());
 
             final String tooShortTerm = randomSimpleString(1, 2);
             results = searcher.search(new Expression(SAITester.createIndexContext("meh", UTF8Type.instance))
-                                                      .add(Operator.EQ, UTF8Type.instance.decompose(tooShortTerm)), SSTableQueryContext.forTest(), false);
+                                                      .add(Operator.EQ, UTF8Type.instance.decompose(tooShortTerm)), SSTableQueryContext.forTest(), false, LIMIT);
             assertFalse(results.hasNext());
         }
     }
@@ -130,7 +132,7 @@ public class InvertedIndexSearcherTest extends SaiRandomizedTest
         try (IndexSearcher searcher = buildIndexAndOpenSearcher(numTerms, numPostings, termsEnum))
         {
             searcher.search(new Expression(SAITester.createIndexContext("meh", UTF8Type.instance))
-                            .add(Operator.GT, UTF8Type.instance.decompose("a")), SSTableQueryContext.forTest(), false);
+                            .add(Operator.GT, UTF8Type.instance.decompose("a")), SSTableQueryContext.forTest(), false, LIMIT);
 
             fail("Expect IllegalArgumentException thrown, but didn't");
         }

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/KDTreeIndexSearcherTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/KDTreeIndexSearcherTest.java
@@ -49,6 +49,8 @@ public class KDTreeIndexSearcherTest extends SaiRandomizedTest
     private static final short RANGE_TEST_LOWER_BOUND_INCLUSIVE = 0;
     private static final short RANGE_TEST_UPPER_BOUND_EXCLUSIVE = 10;
 
+    public static final int LIMIT = Integer.MAX_VALUE;
+
     @Test
     public void testRangeQueriesAgainstInt32Index() throws Exception
     {
@@ -149,7 +151,7 @@ public class KDTreeIndexSearcherTest extends SaiRandomizedTest
             {{
                 operation = Op.NOT_EQ;
                 lower = upper = new Bound(ShortType.instance.decompose((short) 0), Int32Type.instance, true);
-            }}, SSTableQueryContext.forTest(), false);
+            }}, SSTableQueryContext.forTest(), false, LIMIT);
 
             fail("Expect IllegalArgumentException thrown, but didn't");
         }
@@ -167,7 +169,7 @@ public class KDTreeIndexSearcherTest extends SaiRandomizedTest
         {{
             operation = Op.EQ;
             lower = upper = new Bound(rawType.decompose(rawValueProducer.apply(EQ_TEST_LOWER_BOUND_INCLUSIVE)), encodedType, true);
-        }}, SSTableQueryContext.forTest(), false))
+        }}, SSTableQueryContext.forTest(), false, LIMIT))
         {
             assertEquals(results.getMinimum(), results.getCurrent());
             assertTrue(results.hasNext());
@@ -179,7 +181,7 @@ public class KDTreeIndexSearcherTest extends SaiRandomizedTest
         {{
             operation = Op.EQ;
             lower = upper = new Bound(rawType.decompose(rawValueProducer.apply(EQ_TEST_UPPER_BOUND_EXCLUSIVE)), encodedType, true);
-        }}, SSTableQueryContext.forTest(), false))
+        }}, SSTableQueryContext.forTest(), false, LIMIT))
         {
             assertFalse(results.hasNext());
             indexSearcher.close();
@@ -205,7 +207,7 @@ public class KDTreeIndexSearcherTest extends SaiRandomizedTest
 
             lower = new Bound(rawType.decompose(rawValueProducer.apply((short)2)), encodedType, false);
             upper = new Bound(rawType.decompose(rawValueProducer.apply((short)7)), encodedType, true);
-        }}, SSTableQueryContext.forTest(), false))
+        }}, SSTableQueryContext.forTest(), false, LIMIT))
         {
             assertEquals(results.getMinimum(), results.getCurrent());
             assertTrue(results.hasNext());
@@ -218,7 +220,7 @@ public class KDTreeIndexSearcherTest extends SaiRandomizedTest
         {{
             operation = Op.RANGE;
             lower = new Bound(rawType.decompose(rawValueProducer.apply(RANGE_TEST_UPPER_BOUND_EXCLUSIVE)), encodedType, true);
-        }}, SSTableQueryContext.forTest(), false))
+        }}, SSTableQueryContext.forTest(), false, LIMIT))
         {
             assertFalse(results.hasNext());
         }
@@ -227,7 +229,7 @@ public class KDTreeIndexSearcherTest extends SaiRandomizedTest
         {{
             operation = Op.RANGE;
             upper = new Bound(rawType.decompose(rawValueProducer.apply(RANGE_TEST_LOWER_BOUND_INCLUSIVE)), encodedType, false);
-        }}, SSTableQueryContext.forTest(), false))
+        }}, SSTableQueryContext.forTest(), false, LIMIT))
         {
             assertFalse(results.hasNext());
             indexSearcher.close();


### PR DESCRIPTION
Note:
* both flush and compaction use VectorIndexWriter which doesn't support flushing into multiple segments and rebuilds from scratch
* vector files use different file extension from SAI pattern
* each vector segment doesn't support more than 2.1B vectors