### PR TITLE
Allow dense float32[n] in the parser

### DIFF
--- a/src/antlr/Parser.g
+++ b/src/antlr/Parser.g
@@ -1758,6 +1758,7 @@ comparatorType returns [CQL3Type.Raw t]
     : n=native_type     { $t = CQL3Type.Raw.from(n); }
     | c=collection_type { $t = c; }
     | tt=tuple_type     { $t = tt; }
+    | vc=vector_type    { $t = vc; }
     | id=userTypeName   { $t = CQL3Type.Raw.userType(id); }
     | K_FROZEN '<' f=comparatorType '>'
       {
@@ -1801,7 +1802,6 @@ native_type returns [CQL3Type t]
     | K_TIMEUUID  { $t = CQL3Type.Native.TIMEUUID; }
     | K_DATE      { $t = CQL3Type.Native.DATE; }
     | K_TIME      { $t = CQL3Type.Native.TIME; }
-    | K_DENSE_F32 { $t = CQL3Type.Native.DENSE_F32; }
     ;
 
 collection_type returns [CQL3Type.Raw pt]
@@ -1821,6 +1821,11 @@ tuple_type returns [CQL3Type.Raw t]
     @init {List<CQL3Type.Raw> types = new ArrayList<>();}
     @after {$t = CQL3Type.Raw.tuple(types);}
     : K_TUPLE '<' t1=comparatorType { types.add(t1); } (',' tn=comparatorType { types.add(tn); })* '>'
+    ;
+
+vector_type returns [CQL3Type.Raw vt]
+    : K_DENSE_F32  '[' d=INTEGER ']'
+        { $vt = CQL3Type.Raw.vector(Integer.parseInt($d.text)); }
     ;
 
 username

--- a/src/java/org/apache/cassandra/cql3/CQL3Type.java
+++ b/src/java/org/apache/cassandra/cql3/CQL3Type.java
@@ -54,6 +54,11 @@ public interface CQL3Type
         return false;
     }
 
+    default boolean isVector()
+    {
+        return false;
+    }
+
     public AbstractType<?> getType();
 
     /**
@@ -87,8 +92,7 @@ public interface CQL3Type
         TINYINT     (ByteType.instance),
         UUID        (UUIDType.instance),
         VARCHAR     (UTF8Type.instance),
-        VARINT      (IntegerType.instance),
-        DENSE_F32   (DenseFloat32Type.instance);
+        VARINT      (IntegerType.instance);
 
         private final AbstractType<?> type;
 
@@ -501,6 +505,28 @@ public interface CQL3Type
         }
     }
 
+    public static class Vector implements CQL3Type
+    {
+        private final int dimensions;
+
+        public Vector(int dimensions)
+        {
+            this.dimensions = dimensions;
+        }
+
+        @Override
+        public AbstractType<?> getType()
+        {
+            return VectorType.getInstance(dimensions);
+        }
+
+        @Override
+        public String toCQLLiteral(ByteBuffer bytes, ProtocolVersion version)
+        {
+            return "dense float32[" + dimensions + ']';
+        }
+    }
+
     // For UserTypes, we need to know the current keyspace to resolve the
     // actual type used, so Raw is a "not yet prepared" CQL3Type.
     public abstract class Raw
@@ -600,6 +626,11 @@ public interface CQL3Type
         public static Raw tuple(List<CQL3Type.Raw> ts)
         {
             return new RawTuple(ts);
+        }
+
+        public static Raw vector(int dimensions)
+        {
+            return new RawVector(dimensions);
         }
 
         private static class RawType extends Raw
@@ -914,6 +945,41 @@ public interface CQL3Type
                 }
                 sb.append('>');
                 return sb.toString();
+            }
+        }
+
+        private static class RawVector extends Raw
+        {
+            private final int dimensions;
+
+            protected RawVector(int dimensions)
+            {
+                super(false);
+                this.dimensions = dimensions;
+            }
+
+            @Override
+            public boolean supportsFreezing()
+            {
+                return false;
+            }
+
+            @Override
+            public void forEachUserType(Consumer<UTName> userTypeNameConsumer)
+            {
+                // noop
+            }
+
+            @Override
+            public CQL3Type prepare(String keyspace, Types udts) throws InvalidRequestException
+            {
+                return new Vector(dimensions);
+            }
+
+            @Override
+            public String toString()
+            {
+                return "dense float32" + '[' + dimensions + ']';
             }
         }
     }

--- a/src/java/org/apache/cassandra/cql3/Constants.java
+++ b/src/java/org/apache/cassandra/cql3/Constants.java
@@ -434,8 +434,8 @@ public abstract class Constants
 
         public void execute(DecoratedKey partitionKey, UpdateParameters params) throws InvalidRequestException
         {
-            ByteBuffer value = column.type instanceof DenseFloat32Type ? t.bindAndGetVector(params.options)
-                                                                       : t.bindAndGet(params.options);
+            ByteBuffer value = column.type instanceof VectorType ? t.bindAndGetVector(params.options)
+                                                                 : t.bindAndGet(params.options);
             if (value == null)
                 params.addTombstone(column);
             else if (value != ByteBufferUtil.UNSET_BYTE_BUFFER) // use reference equality and not object equality

--- a/src/java/org/apache/cassandra/cql3/Lists.java
+++ b/src/java/org/apache/cassandra/cql3/Lists.java
@@ -27,8 +27,8 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import org.apache.cassandra.db.marshal.ByteBufferAccessor;
-import org.apache.cassandra.db.marshal.DenseFloat32Type;
 import org.apache.cassandra.db.marshal.FloatType;
+import org.apache.cassandra.db.marshal.VectorType;
 import org.apache.cassandra.guardrails.Guardrails;
 import org.apache.cassandra.schema.ColumnMetadata;
 import com.google.common.annotations.VisibleForTesting;
@@ -70,7 +70,7 @@ public abstract class Lists
 
     private static AbstractType<?> elementsType(AbstractType<?> type)
     {
-        if (type instanceof DenseFloat32Type) {
+        if (type instanceof VectorType) {
             return FloatType.instance;
         }
         return ((ListType) unwrap(type)).getElementsType();
@@ -194,7 +194,7 @@ public abstract class Lists
         {
             AbstractType<?> type = unwrap(receiver.type);
 
-            if (!(type instanceof ListType || type instanceof DenseFloat32Type))
+            if (!(type instanceof ListType || type instanceof VectorType))
                 throw new InvalidRequestException(String.format("Invalid list literal for %s of type %s", receiver.name, receiver.type.asCQL3Type()));
 
             ColumnSpecification valueSpec = Lists.valueSpecOf(receiver);

--- a/src/java/org/apache/cassandra/cql3/SingleColumnRelation.java
+++ b/src/java/org/apache/cassandra/cql3/SingleColumnRelation.java
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import org.apache.cassandra.db.marshal.DenseFloat32Type;
+import org.apache.cassandra.db.marshal.VectorType;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.cql3.Term.Raw;
@@ -269,7 +269,7 @@ public final class SingleColumnRelation extends Relation
     protected Restriction newAnnRestriction(TableMetadata table, VariableSpecifications boundNames)
     {
         ColumnMetadata columnDef = table.getExistingColumn(entity);
-        if (!(columnDef.type instanceof DenseFloat32Type))
+        if (!(columnDef.type instanceof VectorType))
             throw invalidRequest("ANN is only supported against DENSE FLOAT32 columns");
         Term term = toTerm(toReceivers(columnDef), value, table.keyspace, boundNames);
         return new SingleColumnRestriction.AnnRestriction(columnDef, term);

--- a/src/java/org/apache/cassandra/db/marshal/AbstractType.java
+++ b/src/java/org/apache/cassandra/db/marshal/AbstractType.java
@@ -279,6 +279,11 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
         return false;
     }
 
+    public boolean isVector()
+    {
+        return false;
+    }
+
     public static AbstractType<?> parseDefaultParameters(AbstractType<?> baseType, TypeParser parser) throws SyntaxException
     {
         Map<String, String> parameters = parser.getKeyValueParameters();

--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -48,9 +48,9 @@ import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.AsciiType;
 import org.apache.cassandra.db.marshal.BooleanType;
 import org.apache.cassandra.db.marshal.CompositeType;
-import org.apache.cassandra.db.marshal.DenseFloat32Type;
 import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.db.marshal.UUIDType;
+import org.apache.cassandra.db.marshal.VectorType;
 import org.apache.cassandra.db.memtable.Memtable;
 import org.apache.cassandra.db.rows.Cell;
 import org.apache.cassandra.db.rows.Row;
@@ -405,7 +405,7 @@ public class IndexContext
         if (op.isLike() || op == Operator.LIKE) return false;
 
         if (op == Operator.ANN)
-            return column.type instanceof DenseFloat32Type;
+            return column.type instanceof VectorType;
 
         Expression.Op operator = Expression.Op.valueOf(op);
 
@@ -496,7 +496,7 @@ public class IndexContext
     public boolean isVector()
     {
         //TODO probably move this down to TypeUtils eventually
-        return getValidator() instanceof DenseFloat32Type;
+        return getValidator().isVector();
     }
 
     public boolean equals(Object obj)

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
@@ -162,8 +162,7 @@ public class StorageAttachedIndex implements Index
                                                                         CQL3Type.Native.SMALLINT, CQL3Type.Native.TEXT, CQL3Type.Native.TIME,
                                                                         CQL3Type.Native.TIMESTAMP, CQL3Type.Native.TIMEUUID, CQL3Type.Native.TINYINT,
                                                                         CQL3Type.Native.UUID, CQL3Type.Native.VARCHAR, CQL3Type.Native.INET,
-                                                                        CQL3Type.Native.VARINT, CQL3Type.Native.DECIMAL, CQL3Type.Native.BOOLEAN,
-                                                                        CQL3Type.Native.DENSE_F32);
+                                                                        CQL3Type.Native.VARINT, CQL3Type.Native.DECIMAL, CQL3Type.Native.BOOLEAN);
 
     private static final Set<Class<? extends IPartitioner>> ILLEGAL_PARTITIONERS =
             ImmutableSet.of(OrderPreservingPartitioner.class, LocalPartitioner.class, ByteOrderedPartitioner.class, RandomPartitioner.class);
@@ -262,7 +261,7 @@ public class StorageAttachedIndex implements Index
                     throw new InvalidRequestException("Unsupported composite type for SAI: " + subType.asCQL3Type());
             }
         }
-        else if (!SUPPORTED_TYPES.contains(type.asCQL3Type()) && !TypeUtil.isFrozen(type))
+        else if (!type.isVector() && !SUPPORTED_TYPES.contains(type.asCQL3Type()) && !TypeUtil.isFrozen(type))
         {
             throw new InvalidRequestException("Unsupported type for SAI: " + type.asCQL3Type());
         }

--- a/src/java/org/apache/cassandra/index/sai/disk/hnsw/VectorMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/hnsw/VectorMemtableIndex.java
@@ -34,7 +34,7 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.Clustering;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.PartitionPosition;
-import org.apache.cassandra.db.marshal.DenseFloat32Type;
+import org.apache.cassandra.db.marshal.VectorType;
 import org.apache.cassandra.db.memtable.Memtable;
 import org.apache.cassandra.dht.AbstractBounds;
 import org.apache.cassandra.dht.Token;
@@ -110,7 +110,7 @@ public class VectorMemtableIndex implements MemtableIndex
         assert expr.getOp() == Expression.Op.ANN : "Only ANN is supported for vector search, received " + expr.getOp();
 
         var buffer = expr.lower.value.raw;
-        var qv = DenseFloat32Type.Serializer.instance.deserialize(buffer);
+        var qv = VectorType.Serializer.instance.deserialize(buffer);
         NeighborQueue nn;
         try
         {
@@ -240,7 +240,7 @@ public class VectorMemtableIndex implements MemtableIndex
         @Override
         public float[] vectorValue(int i)
         {
-            return DenseFloat32Type.Serializer.instance.deserialize(buffers.get(i));
+            return VectorType.Serializer.instance.deserialize(buffers.get(i));
         }
 
         public float[] add(ByteBuffer buffer) {

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/IndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/IndexSearcher.java
@@ -20,7 +20,6 @@ package org.apache.cassandra.index.sai.disk.v1;
 import java.io.Closeable;
 import java.io.IOException;
 
-import org.apache.cassandra.db.marshal.DenseFloat32Type;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.SSTableQueryContext;
 import org.apache.cassandra.index.sai.disk.IndexSearcherContext;
@@ -65,7 +64,7 @@ public abstract class IndexSearcher implements Closeable
                                      IndexDescriptor indexDescriptor,
                                      IndexContext indexContext) throws IOException
     {
-        if (indexContext.getValidator() instanceof DenseFloat32Type)
+        if (indexContext.isVector())
             return new VectorIndexSearcher(primaryKeyMapFactory, indexFiles, segmentMetadata, indexDescriptor, indexContext);
         if (TypeUtil.isLiteral(indexContext.getValidator()))
             return new InvertedIndexSearcher(primaryKeyMapFactory, indexFiles, segmentMetadata, indexDescriptor, indexContext);

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/MemtableIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/MemtableIndexWriter.java
@@ -31,7 +31,6 @@ import org.slf4j.LoggerFactory;
 import com.carrotsearch.hppc.LongArrayList;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.marshal.AbstractType;
-import org.apache.cassandra.db.marshal.DenseFloat32Type;
 import org.apache.cassandra.db.rows.Row;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.disk.MemtableTermsIterator;
@@ -68,7 +67,7 @@ public class MemtableIndexWriter implements PerIndexWriter
     {
         assert rowMapping != null && rowMapping != RowMapping.DUMMY : "Row mapping must exist during FLUSH.";
 
-        Preconditions.checkState(!(indexContext.getValidator() instanceof DenseFloat32Type));
+        Preconditions.checkState(!(indexContext.isVector()));
         this.indexDescriptor = indexDescriptor;
         this.indexContext = indexContext;
         this.memtable = memtable;

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/PerIndexFiles.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/PerIndexFiles.java
@@ -22,7 +22,6 @@ import java.io.Closeable;
 import java.util.EnumMap;
 import java.util.Map;
 
-import org.apache.cassandra.db.marshal.DenseFloat32Type;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.disk.format.IndexComponent;
 import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
@@ -40,7 +39,7 @@ public class PerIndexFiles implements Closeable
     {
         this.indexDescriptor = indexDescriptor;
         this.indexContext = indexContext;
-        if (indexContext.getValidator() instanceof DenseFloat32Type)
+        if (indexContext.isVector())
         {
             // TODO  lucene doesn't follow SAI file patterns
         }

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SSTableIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SSTableIndexWriter.java
@@ -32,7 +32,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.db.marshal.AbstractType;
-import org.apache.cassandra.db.marshal.DenseFloat32Type;
 import org.apache.cassandra.db.rows.Row;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.analyzer.AbstractAnalyzer;
@@ -372,7 +371,7 @@ public class SSTableIndexWriter implements PerIndexWriter
     private SegmentBuilder newSegmentBuilder()
     {
         // vector uses VectorIndexSearcher
-        Preconditions.checkState(!(indexContext.getValidator() instanceof DenseFloat32Type));
+        Preconditions.checkState(!(indexContext.isVector()));
 
         SegmentBuilder builder = TypeUtil.isLiteral(indexContext.getValidator())
                                  ? new SegmentBuilder.RAMStringSegmentBuilder(indexContext.getValidator(), limiter)

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/V1OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/V1OnDiskFormat.java
@@ -31,7 +31,6 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.ClusteringComparator;
 import org.apache.cassandra.db.compaction.OperationType;
 import org.apache.cassandra.db.lifecycle.LifecycleNewTracker;
-import org.apache.cassandra.db.marshal.DenseFloat32Type;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.SSTableContext;
 import org.apache.cassandra.index.sai.StorageAttachedIndex;
@@ -177,13 +176,13 @@ public class V1OnDiskFormat implements OnDiskFormat
             logger.info(index.getIndexContext().logMessage("Starting a compaction index build. Global segment memory usage: {}"),
                         prettyPrintMemory(limiter.currentBytesUsed()));
 
-            if (index.getIndexContext().getValidator() instanceof DenseFloat32Type)
+            if (index.getIndexContext().isVector())
                 return new VectorIndexWriter(indexDescriptor, index.getIndexContext());
 
             return new SSTableIndexWriter(indexDescriptor, index.getIndexContext(), limiter, index.isIndexValid());
         }
 
-        if (index.getIndexContext().getValidator() instanceof DenseFloat32Type)
+        if (index.getIndexContext().isVector())
             return new VectorIndexWriter(indexDescriptor, index.getIndexContext()
             );
 
@@ -262,7 +261,7 @@ public class V1OnDiskFormat implements OnDiskFormat
     @Override
     public Set<IndexComponent> perIndexComponents(IndexContext indexContext)
     {
-        if (indexContext.getValidator() instanceof DenseFloat32Type)
+        if (indexContext.isVector())
             return VECTOR_COMPONENTS;
         else if (TypeUtil.isLiteral(indexContext.getValidator()))
             return LITERAL_COMPONENTS;

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/VectorIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/VectorIndexSearcher.java
@@ -29,7 +29,7 @@ import com.google.common.base.MoreObjects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.cassandra.db.marshal.DenseFloat32Type;
+import org.apache.cassandra.db.marshal.VectorType;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.SSTableQueryContext;
 import org.apache.cassandra.index.sai.disk.IndexSearcherContext;
@@ -110,7 +110,7 @@ public class VectorIndexSearcher extends IndexSearcher
         String field = indexContext.getIndexName();
 
         ByteBuffer buffer = exp.lower.value.raw;
-        float[] queryVector = DenseFloat32Type.Serializer.instance.deserialize(buffer.duplicate());
+        float[] queryVector = VectorType.Serializer.instance.deserialize(buffer.duplicate());
 
         Bits bits = null; // TODO filter partitions inside ANN search
         TopDocs docs = reader.search(field, queryVector, limit, bits, Integer.MAX_VALUE);

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/VectorIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/VectorIndexWriter.java
@@ -29,7 +29,7 @@ import com.google.common.base.Stopwatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.cassandra.db.marshal.DenseFloat32Type;
+import org.apache.cassandra.db.marshal.VectorType;
 import org.apache.cassandra.db.rows.Row;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.disk.PerIndexWriter;
@@ -78,7 +78,7 @@ public class VectorIndexWriter implements PerIndexWriter
 
     public VectorIndexWriter(IndexDescriptor indexDescriptor, IndexContext indexContext)
     {
-        Preconditions.checkState(indexContext.getValidator() instanceof DenseFloat32Type);
+        Preconditions.checkState(indexContext.isVector());
 
         this.indexDescriptor = indexDescriptor;
         this.indexContext = indexContext;
@@ -101,7 +101,7 @@ public class VectorIndexWriter implements PerIndexWriter
         ByteBuffer value = indexContext.getValueOf(key.partitionKey(), row, nowInSec);
         if (value != null)
         {
-            float[] vector = DenseFloat32Type.Serializer.instance.deserialize(value.duplicate());
+            float[] vector = VectorType.Serializer.instance.deserialize(value.duplicate());
             try
             {
                 maybeCreateWriter(vector.length);

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -48,7 +48,6 @@ import org.apache.cassandra.db.filter.ClusteringIndexFilter;
 import org.apache.cassandra.db.filter.ClusteringIndexNamesFilter;
 import org.apache.cassandra.db.filter.DataLimits;
 import org.apache.cassandra.db.filter.RowFilter;
-import org.apache.cassandra.db.marshal.DenseFloat32Type;
 import org.apache.cassandra.db.rows.UnfilteredRowIterator;
 import org.apache.cassandra.dht.AbstractBounds;
 import org.apache.cassandra.dht.Range;
@@ -387,7 +386,7 @@ public class QueryController
             NavigableSet<SSTableIndex> indexes = new TreeSet<>(SSTableIndex.COMPARATOR);
 
             // always search all for ANN
-            if (e.context.getValidator() instanceof DenseFloat32Type)
+            if (e.context.isVector())
                 indexes.addAll(view.getIndexes());
             else
                 indexes.addAll(applyScope(view.match(e)));

--- a/test/unit/org/apache/cassandra/cql3/CQL3TypeLiteralTest.java
+++ b/test/unit/org/apache/cassandra/cql3/CQL3TypeLiteralTest.java
@@ -23,14 +23,52 @@ import java.math.BigInteger;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.EnumMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.UUID;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.junit.Test;
 
-import org.apache.cassandra.db.marshal.*;
-import org.apache.cassandra.serializers.*;
+import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.db.marshal.BooleanType;
+import org.apache.cassandra.db.marshal.ByteType;
+import org.apache.cassandra.db.marshal.BytesType;
+import org.apache.cassandra.db.marshal.CollectionType;
+import org.apache.cassandra.db.marshal.DecimalType;
+import org.apache.cassandra.db.marshal.DoubleType;
+import org.apache.cassandra.db.marshal.FloatType;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.marshal.IntegerType;
+import org.apache.cassandra.db.marshal.ListType;
+import org.apache.cassandra.db.marshal.LongType;
+import org.apache.cassandra.db.marshal.MapType;
+import org.apache.cassandra.db.marshal.SetType;
+import org.apache.cassandra.db.marshal.ShortType;
+import org.apache.cassandra.db.marshal.TimeUUIDType;
+import org.apache.cassandra.db.marshal.TimestampType;
+import org.apache.cassandra.db.marshal.TupleType;
+import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.db.marshal.UUIDType;
+import org.apache.cassandra.db.marshal.UserType;
+import org.apache.cassandra.serializers.AsciiSerializer;
+import org.apache.cassandra.serializers.BytesSerializer;
+import org.apache.cassandra.serializers.CollectionSerializer;
+import org.apache.cassandra.serializers.DurationSerializer;
+import org.apache.cassandra.serializers.InetAddressSerializer;
+import org.apache.cassandra.serializers.SimpleDateSerializer;
+import org.apache.cassandra.serializers.TimeSerializer;
+import org.apache.cassandra.serializers.TimestampSerializer;
+import org.apache.cassandra.serializers.UTF8Serializer;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.UUIDGen;
@@ -265,18 +303,18 @@ public class CQL3TypeLiteralTest
         addNativeValue("null", CQL3Type.Native.INET, ByteBufferUtil.EMPTY_BYTE_BUFFER);
         addNativeValue("null", CQL3Type.Native.INET, null);
 
-        for (int i = 0; i < 20; i++)
-        {
-            int n = randInt(200);
-            var v = new float[n];
-            for (int j = 0; j < n; j++)
-                v[j] = randFloat();
-            addNativeValue(DenseFloat32Type.Serializer.instance.toString(v),
-                           CQL3Type.Native.DENSE_F32,
-                           DenseFloat32Type.Serializer.instance.serialize(v));
-        }
-        addNativeValue("null", CQL3Type.Native.DENSE_F32, ByteBufferUtil.EMPTY_BYTE_BUFFER);
-        addNativeValue("null", CQL3Type.Native.DENSE_F32, null);
+//        for (int i = 0; i < 20; i++)
+//        {
+//            int n = randInt(200);
+//            var v = new float[n];
+//            for (int j = 0; j < n; j++)
+//                v[j] = randFloat();
+//            addNativeValue(DenseFloat32Type.Serializer.instance.toString(v),
+//                           CQL3Type.Native.DENSE_F32,
+//                           DenseFloat32Type.Serializer.instance.serialize(v));
+//        }
+//        addNativeValue("null", CQL3Type.Native.DENSE_F32, ByteBufferUtil.EMPTY_BYTE_BUFFER);
+//        addNativeValue("null", CQL3Type.Native.DENSE_F32, null);
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/index/sai/cql/AnnTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/AnnTest.java
@@ -30,7 +30,7 @@ public class AnnTest extends SAITester
     @Test
     public void endToEndTest() throws Throwable
     {
-        createTable("CREATE TABLE %s (pk int, str_val text, val dense float32, PRIMARY KEY(pk))");
+        createTable("CREATE TABLE %s (pk int, str_val text, val dense float32[3], PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
         waitForIndexQueryable();
 

--- a/test/unit/org/apache/cassandra/index/sai/memory/VectorMemtableIndexTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/memory/VectorMemtableIndexTest.java
@@ -38,8 +38,8 @@ import org.apache.cassandra.db.Clustering;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.PartitionPosition;
-import org.apache.cassandra.db.marshal.DenseFloat32Type;
 import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.marshal.VectorType;
 import org.apache.cassandra.dht.AbstractBounds;
 import org.apache.cassandra.dht.BootStrapper;
 import org.apache.cassandra.dht.Bounds;
@@ -168,7 +168,7 @@ public class VectorMemtableIndexTest extends SAITester
         for (int i = 0; i < dimensionCount; i++) {
             rawVector[i] = getRandom().nextFloat();
         }
-        return DenseFloat32Type.Serializer.instance.serialize(rawVector);
+        return VectorType.Serializer.instance.serialize(rawVector);
     }
 
     private AbstractBounds<PartitionPosition> generateRandomBounds(List<DecoratedKey> keys)


### PR DESCRIPTION
 - This changes the AbstractType from DenseFloat32Type to VectorType that takes the number of dimensions declared in the CQL.

Note: We should use IndexContext.isVector as the test for vector usage rather than instanceof on the type.